### PR TITLE
Efficient i/o for board printout

### DIFF
--- a/Pos2.cpp
+++ b/Pos2.cpp
@@ -88,8 +88,8 @@ void Pos2::MakeMoveBB(int square) {
 ///////////////////////////////////////////////////////////////////////////////
 
 // debug stuff
-void FPrintHeader(FILE* fp);
-void FPrintRow(FILE* fp, int row, int pattern, int nColors[3]);
+void FPrintHeader(std::stringstream &ss);
+void FPrintRow(std::stringstream &ss, int row, int pattern, int nColors[3]);
 void PrintSquareDirectionToPattern();
 void PrintSquareDirectionToValue();
 
@@ -99,8 +99,9 @@ void Pos2::Print() const {
 
 void Pos2::FPrint(FILE* fp) const {
     int row, nColors[3];
+    std::stringstream ss;
 
-    FPrintHeader(fp);
+    FPrintHeader(ss);
 
     uint64_t black;
     if (this->BlackMove()) {
@@ -115,14 +116,18 @@ void Pos2::FPrint(FILE* fp) const {
                 base2ToBase3Table[(m_bb.empty >> (row * 8))& 0xff] +
                 base2ToBase3Table[(black >> (row * 8))& 0xff] * 2;
 
-        FPrintRow(fp, row, rowPattern, nColors);
+        FPrintRow(ss, row, rowPattern, nColors);
     }
 
-    FPrintHeader(fp);
+    FPrintHeader(ss);
 
-    fprintf(fp, "\nBlack: %d  White: %d  Empty: %d\n\n",nColors[2],nColors[0],nColors[1]);
-    fprintf(fp, "%s to move\n",m_fBlackMove?"Black":"White");
+    ss << "\nBlack: " << nColors[2] << "  White: " << nColors[0] << "  Empty: " << nColors[1] << "\n\n";
+    ss << (m_fBlackMove ? "Black" : "White") << " to move\n";
+
+    std::string output = ss.str();
+    fwrite(output.c_str(), 1, output.size(), fp);
 }
+
 void Pos2::PrintStable() const {
     FPrintStable(stdout);
 }
@@ -131,57 +136,65 @@ void Pos2::PrintStableNext() const {
 }
 void Pos2::FPrintStable(FILE* fp) const {
     int row, nColors[3];
+    std::stringstream ss;
 
-    FPrintHeader(fp);
+    FPrintHeader(ss);
 
     nColors[0]=nColors[1]=nColors[2]=0;
     for (row=0; row<N; row++) {
         uint64_t bitrow = (m_stable >> (row * 8))& 0xff;
         // print row number
-        fprintf(fp, "%-2d", row+1);
+        ss << std::setw(2) << row + 1;
 
         // break row apart into values and print value
         for (int col=0; col<N; col++) {
             auto item = bitrow & 1;
             bitrow >>= 1;
-            fprintf(fp, "%c ", item? 'X' : '-');
+            ss << " " << (item ? 'X' : '-');
         }
 
         //print row number at right of row
-        fprintf(fp, "%2d\n", row+1);
+        ss << " " << std::setw(2) << row + 1 << "\n";
     }
 
-    FPrintHeader(fp);
+    FPrintHeader(ss);
 
-    fprintf(fp, "\nBlack: %d  White: %d  Empty: %d\n\n",nColors[2],nColors[0],nColors[1]);
-    fprintf(fp, "%s to move\n",m_fBlackMove?"Black":"White");
+    ss << "\nBlack: " << nColors[2] << "  White: " << nColors[0] << "  Empty: " << nColors[1] << "\n\n";
+    ss << (m_fBlackMove ? "Black" : "White") << " to move\n";
+
+    std::string output = ss.str();
+    fwrite(output.c_str(), 1, output.size(), fp);
 }
 void Pos2::FPrintStableNext(FILE* fp) const {
     int row, nColors[3];
+    std::stringstream ss;
 
-    FPrintHeader(fp);
+    FPrintHeader(ss);
 
     nColors[0]=nColors[1]=nColors[2]=0;
     for (row=0; row<N; row++) {
         uint64_t bitrow = (m_stable_trigger >> (row * 8))& 0xff;
         // print row number
-        fprintf(fp, "%-2d", row+1);
+        ss << std::setw(2) << row + 1;
 
         // break row apart into values and print value
         for (int col=0; col<N; col++) {
             auto item = bitrow & 1;
             bitrow >>= 1;
-            fprintf(fp, "%c ", item? 'X' : '-');
+            ss << " " << (item ? 'X' : '-');
         }
 
         //print row number at right of row
-        fprintf(fp, "%2d\n", row+1);
+        ss << " " << std::setw(2) << row + 1 << "\n";
     }
 
-    FPrintHeader(fp);
+    FPrintHeader(ss);
 
-    fprintf(fp, "\nBlack: %d  White: %d  Empty: %d\n\n",nColors[2],nColors[0],nColors[1]);
-    fprintf(fp, "%s to move\n",m_fBlackMove?"Black":"White");
+    ss << "\nBlack: " << nColors[2] << "  White: " << nColors[0] << "  Empty: " << nColors[1] << "\n\n";
+    ss << (m_fBlackMove ? "Black" : "White") << " to move\n";
+
+    std::string output = ss.str();
+    fwrite(output.c_str(), 1, output.size(), fp);
 }
 
 char* Pos2::GetText(char* sBoard) const {
@@ -214,31 +227,30 @@ char* Pos2::GetText(char* sBoard) const {
 // Debug and print functions - protected
 ///////////////////////////////////////////////////////////////////
 
-void FPrintHeader(FILE* fp) {
+void FPrintHeader(std::stringstream &ss) {
     int col;
-
-    fprintf(fp, "  ");
+    ss << "  ";
     for (col=0; col<N; col++)
-        fprintf(fp, "%c ",col+'A');
-    fprintf(fp, "\n");
+        ss << " " << static_cast<char>('A' + col);
+    ss << "\n";
 }
 
-void FPrintRow(FILE* fp, int row, int config, int nColors[3]) {
+void FPrintRow(std::stringstream &ss, int row, int config, int nColors[3]) {
     int col, item;
 
     // print row number
-    fprintf(fp, "%-2d", row+1);
+    ss << std::setw(2) << row + 1;
 
     // break row apart into values and print value
     for (col=0; col<N; col++) {
-        item=config%3;
+        item = config%3;
         config=(config-item)/3;
-        fprintf(fp, "%c ",ValueToText(item));
+        ss << " " << ValueToText(item);
         nColors[item]++;
     }
 
     //print row number at right of row
-    fprintf(fp, "%2d\n", row+1);
+    ss << " " << std::setw(2) << row + 1 << "\n";
 }
 
 // CalcMovesAndPass - calc moves. decide if the mover needs to pass, and pass if he does

--- a/core/BitBoard.cpp
+++ b/core/BitBoard.cpp
@@ -7,6 +7,7 @@
 
 #include <cstring>
 
+#include <iomanip>
 #include "BitBoard.h"
 #include "Moves.h"
 #include "../port.h"
@@ -111,26 +112,26 @@ void CBitBoard::Print(bool fBlackMove) const {
     FPrint(stdout, fBlackMove);
 }
 
-void CBitBoard::FPrintHeader(FILE* fp) const {
+void CBitBoard::FPrintHeader(std::stringstream &ss) const {
     int col;
-
-    fprintf(fp,"  ");
+    ss << "  ";
     for (col=0; col<N; col++)
-    	fprintf(fp, " %c", 'A'+col);
-    fprintf(fp, "\n");
+        ss << " " << static_cast<char>('A' + col);
+    ss << "\n";
 }
 
 void CBitBoard::FPrint(FILE* fp, bool fBlackMove) const {
     int row,col;
     u2 e,b;
     int value;
+    std::stringstream ss;
 
-    fprintf(fp, "\n");
+    ss << "\n";
 
     // print the board
-    FPrintHeader(fp);
+    FPrintHeader(ss);
     for (row=0; row<N; row++) {
-    	fprintf(fp, "%2d ",row+1);
+    	ss << std::setw(2) << row + 1 << " ";
     	e=u1(empty >> row*8);
     	b=u1(mover >> row*8);
     	if (!fBlackMove)
@@ -142,16 +143,20 @@ void CBitBoard::FPrint(FILE* fp, bool fBlackMove) const {
     			value=(b&1)?BLACK:WHITE;
     		e>>=1;
     		b>>=1;
-    		fprintf(fp, "%c ",ValueToText(value));
+    		ss << ValueToText(value) << " ";
     	}
-    	fprintf(fp, "%2d\n",row+1);
+    	ss << std::setw(2) << row + 1 << "\n";
     }
-    FPrintHeader(fp);
+    FPrintHeader(ss);
 
     // disc info
     int nEmpty, nBlack, nWhite;
     NDiscs(fBlackMove, nBlack, nWhite, nEmpty);
-    fprintf(fp,"Black: %d  White: %d  Empty: %d\n", nBlack, nWhite, nEmpty);
+    ss << "Black: " << nBlack << "  White: " << nWhite << "  Empty: " << nEmpty << "\n";
+
+    // Write the entire buffer to the file at once
+    std::string output = ss.str();
+    fwrite(output.c_str(), 1, output.size(), fp);
 }
 
 //! Output the bitboard to a char buffer, and return the char buffer plus a terminal '\0'

--- a/core/BitBoard.h
+++ b/core/BitBoard.h
@@ -8,6 +8,7 @@
 
 
 #include <cassert>
+#include <sstream>
 #include <stdio.h>
 #include "../n64/utils.h"
 class CMoves;
@@ -65,7 +66,7 @@ public:
     u64 getEnemy() const { return ~(u64(mover)|u64(empty)); }
 
 protected:
-    void FPrintHeader(FILE* fp) const;
+    void FPrintHeader(std::stringstream &ss) const;
 };
 
 bool operator<(const CBitBoard& a, const CBitBoard& b);


### PR DESCRIPTION
Replace fprintf with buffered std::stringstream. This reduces the number of write syscalls significantly. Instead of each cell of the board written out one at a time, we store all the cells into a buffer along with the border, and write the board once.

No algorithmic changes, no output formatting changes. This only modifies how often i/o is flushed so benchmark may scale better for high core counts.